### PR TITLE
fix: token rotation didn't update client auth

### DIFF
--- a/panther_seim/alerts.py
+++ b/panther_seim/alerts.py
@@ -168,7 +168,6 @@ class AlertsInterface(GraphInterfaceBase):
                 "alerts/update_status.gql", {"input": {"ids": alertids, "status": status}}
             )
             for result in results["updateAlertStatusById"]["alerts"]:
-                print(result)
                 alerts[result["id"]].update(result)
 
         if len(alerts) == 1:

--- a/panther_seim/cloud_accounts.py
+++ b/panther_seim/cloud_accounts.py
@@ -152,7 +152,6 @@ class CloudAccountsInterface(GraphInterfaceBase):
             values["resourceTypeIgnoreList"] = resource_type_ignore
         try:
             result = self.execute_gql("cloud_accounts/create.gql", {"input": values})
-            print(result)
             return result["createCloudAccount"]["cloudAccount"]["id"]
         except TransportQueryError as e:
             for err in e.errors:
@@ -181,7 +180,6 @@ class CloudAccountsInterface(GraphInterfaceBase):
 
         # Invoke API
         results = self.execute_gql("cloud_accounts/delete.gql", {"id": accountid})
-        print(results)
         return results["deleteCloudAccount"]["id"]
 
     # pylint: disable=too-many-arguments, too-many-branches

--- a/panther_seim/tokens.py
+++ b/panther_seim/tokens.py
@@ -15,7 +15,6 @@ class TokensInterface(GraphInterfaceBase):
         several seconds before the new token value is valid.
         """
         resp = self.execute_gql("tokens/rotate.gql")
-        print(resp)
         token = resp["rotateAPIToken"]["token"]["value"]
 
         # -- Update Panther client object
@@ -23,6 +22,6 @@ class TokensInterface(GraphInterfaceBase):
         # To reset the auth for the GQL client, we can just delete the current client. The next GQL
         #   call will trigger a new client to be created, with the new token value for
         #   authentication.
-        self.root._gql_client = None  # pylint: disable=protected-access
+        del self.root._gql_client  # pylint: disable=protected-access
 
         return token


### PR DESCRIPTION
When rotating the token, a logic oversight meant that the current GQL client wasn't being regenerated with the new token value, and subsequent API calls failed to validate.

Additionally, a number of `print` statements for debugging were left in by mistake, so I cleared those out too.