### PR TITLE
Refactor: Updating to Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "panther_seim"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 gql = "^3.4.1"
 aiohttp = "^3.9.1"
 pytz = "^2023.3.post1"


### PR DESCRIPTION
Turns out `enum` doesn't have `StrEnum` in version 3.10. Unsure why this wasn't an issue on my other machine, but updating the project requirements/dependencies to account for this!