### PR TITLE
feat: added option to ignore 404s on delete

### DIFF
--- a/panther_seim/data_models.py
+++ b/panther_seim/data_models.py
@@ -189,11 +189,13 @@ class DataModelInterface(RestInterfaceBase):
             raise PantherError(f"Invalid data model: {resp.text}")
         return get_rest_response(resp)
 
-    def delete(self, model_id: str) -> None:
+    def delete(self, model_id: str, ignore404: bool = False) -> None:
         """Deletes a data model.
 
         Args:
             id (str): the ID of the model to delete.
+            ignore404 (bool, optional): whether to raise an error if the model doesn't exist
+                Set to True to suppress an EntityNotFoundError
         """
 
         resp = self._send_request("DELETE", f"data_models/{model_id}")
@@ -203,9 +205,11 @@ class DataModelInterface(RestInterfaceBase):
             case 400:
                 raise PantherError(f"Invalid delete request: {resp.text}")
             case 404:
-                raise EntityNotFoundError(
-                    f"Cannot delete model with ID {model_id}; ID does not exist"
-                )
+                if not ignore404:
+                    raise EntityNotFoundError(
+                        f"Cannot delete model with ID {model_id}; ID does not exist"
+                    )
+                return
 
         # If none of the status codes above matched, then this is an unknown error.
         raise PantherError(f"Unknown error with code {resp.status_code}: {resp.text}")

--- a/panther_seim/globals.py
+++ b/panther_seim/globals.py
@@ -138,11 +138,13 @@ class GlobalInterface(RestInterfaceBase):
                 # If none of the status codes above matched, then this is an unknown error.
                 raise PantherError(f"Unknown error with code {resp.status_code}: {resp.text}")
 
-    def delete(self, global_id) -> None:
+    def delete(self, global_id, ignore404: bool = False) -> None:
         """Deletes a global helper.
 
         Args:
             global_id (str): The ID of the global helper to delete
+            ignore404 (bool, optional): whether to raise an error if the global doesn't exist
+                Set to True to suppress an EntityNotFoundError
         """
         resp = self._send_request("DELETE", f"globals/{global_id}")
 
@@ -153,9 +155,11 @@ class GlobalInterface(RestInterfaceBase):
             case 400:
                 raise PantherError(f"Invalid request: {resp.text}")
             case 404:
-                raise EntityNotFoundError(
-                    f"Cannot delete global with ID {global_id}; ID does not exist"
-                )
+                if not ignore404:
+                    raise EntityNotFoundError(
+                        f"Cannot delete global with ID {global_id}; ID does not exist"
+                    )
+                return
             case _:
                 # If none of the status codes above matched, then this is an unknown error.
                 raise PantherError(f"Unknown error with code {resp.status_code}: {resp.text}")

--- a/panther_seim/queries.py
+++ b/panther_seim/queries.py
@@ -208,11 +208,13 @@ class QueriesInterface(RestInterfaceBase):
                 # If none of the status codes above matched, then this is an unknown error.
                 raise PantherError(f"Unknown error with code {resp.status_code}: {resp.text}")
 
-    def delete(self, query_id) -> None:
+    def delete(self, query_id, ignore404: bool = False) -> None:
         """Deletes a saved query.
 
         Args:
             query_id (str): The ID of the saved or scheduled query to delete
+            ignore404 (bool, optional): whether to raise an error if the model doesn't exist
+                Set to True to suppress an EntityNotFoundError
         """
         query_id = to_uuid(query_id)
         resp = self._send_request("DELETE", f"queries/{query_id}")
@@ -224,9 +226,11 @@ class QueriesInterface(RestInterfaceBase):
             case 400:
                 raise PantherError(f"Invalid request: {resp.text}")
             case 404:
-                raise EntityNotFoundError(
-                    f"Cannot delete query with ID {query_id}; ID does not exist"
-                )
+                if not ignore404:
+                    raise EntityNotFoundError(
+                        f"Cannot delete query with ID {query_id}; ID does not exist"
+                    )
+                return
             case _:
                 # If none of the status codes above matched, then this is an unknown error.
                 raise PantherError(f"Unknown error with code {resp.status_code}: {resp.text}")


### PR DESCRIPTION
There may be cases where users don't want to be alerted if a resource being deleted doesn't exist, so this flag allows a user to control whether an EntityNotFound exception is raised or not. This flag is only added to the REST-API functions (`data_models`, `queries`, and `globals`, so far). Any interfaces using the GQL client already don't raise an EntityNotFound error, since the GQL API doesn't raise an error.